### PR TITLE
[PROD]<-ci(workflow): fix branch checkout in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,6 +49,7 @@ jobs:
         run: poetry run get_coverage
       - name: Ferch repo
         run: |
+        
           git commit -am "Automated coverage report"
           git push 
       - name: Run build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,6 +66,7 @@ jobs:
           path: coverage.xml
   coverage:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
     needs: build 
     steps:
       - name: Download coverage.xml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Run tests
         run: poetry run test
       - name: Run coverage report
-        run: poetry run get_coverage
+        run: |
+          poetry run get_coverage
+          git status
       - name: Push changes
         run: |
           git status

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,13 +31,12 @@ jobs:
       - name: Install deps
         run: poetry install
       - name: Ferch repo
-        # ${{github.event.pull_request.head.ref}}
         run: |
           git status
           git config --global user.name 'Git bot'
           git config --global user.email 'gitbot@users.noreply.github.com'
           git fetch origin
-          git checkout origin/main
+          git checkout --track origin/${{github.event.pull_request.head.ref}}
           git pull 
       - name: Bump version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,12 +36,12 @@ jobs:
           git checkout --track origin/${{github.event.pull_request.head.ref}}
           git pull 
       - name: Bump version
-        if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           poetry version patch
           VERSION=$(poetry version -s)
       - name: Push changes
-        if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git status
           git commit -am "Version Bump"
@@ -66,7 +66,7 @@ jobs:
           path: coverage.xml
   coverage:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build 
     steps:
       - name: Download coverage.xml
@@ -80,6 +80,7 @@ jobs:
           files: coverage.xml
             
   publish-to-pypi:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
     needs:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Push changes
         run: |
           git status
-          git commit -am "Automated coverage report"
+          git commit -am "Version Bump"
           git push 
       - name: Run build
         run: poetry build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,15 +1,6 @@
 name: CI/CD
-on: 
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  release:
-    types: [created]
-    branches:
-      - main
+on: pull_request
+
 jobs:
   build:
     strategy:
@@ -39,7 +30,6 @@ jobs:
           git checkout --track origin/${{github.event.pull_request.head.ref}}
           git pull 
       - name: Bump version
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           poetry version patch
           VERSION=$(poetry version -s)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,14 +51,24 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+      - name: Store the coverage xml
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
   coverage:
     runs-on: ubuntu-latest
     needs: build 
     steps:
+      - name: Download coverage.xml
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
       - uses: qltysh/qlty-action/coverage@v1
         with:
           token: ${{secrets.QLTY_COVERAGE_TOKEN}}
-          files: ${{github.workspace}}/coverage.xml:coverage.py
+          files: coverage.xml:coverage.py
             
   publish-to-pypi:
     name: >-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,5 +1,11 @@
 name: CI/CD
-on: pull_request
+on: 
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -30,20 +36,22 @@ jobs:
           git checkout --track origin/${{github.event.pull_request.head.ref}}
           git pull 
       - name: Bump version
+        if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
         run: |
           poetry version patch
           VERSION=$(poetry version -s)
+      - name: Push changes
+        if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          git status
+          git commit -am "Version Bump"
+          git push 
       - name: Run tests
         run: poetry run test
       - name: Run coverage report
         run: |
           poetry run get_coverage
           git status
-      - name: Push changes
-        run: |
-          git status
-          git commit -am "Version Bump"
-          git push 
       - name: Run build
         run: poetry build
       - name: Store the distribution packages

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: qltysh/qlty-action/coverage@v1
         with:
           token: ${{secrets.QLTY_COVERAGE_TOKEN}}
-          files: coverage.xml:coverage.py
+          files: coverage.xml
             
   publish-to-pypi:
     name: >-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,9 +47,9 @@ jobs:
         run: poetry run test
       - name: Run coverage report
         run: poetry run get_coverage
-      - name: Ferch repo
+      - name: Push changes
         run: |
-        
+          git status
           git commit -am "Automated coverage report"
           git push 
       - name: Run build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "producteca"
-version = "1.0.9"
+version = "1.0.10"
 description = ""
 authors = ["Chroma Agency, Matias Rivera <mrivera@chroma.agency>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "producteca"
-version = "1.0.7"
+version = "1.0.8"
 description = ""
 authors = ["Chroma Agency, Matias Rivera <mrivera@chroma.agency>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "producteca"
-version = "1.0.10"
+version = "1.0.11"
 description = ""
 authors = ["Chroma Agency, Matias Rivera <mrivera@chroma.agency>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "producteca"
-version = "1.0.8"
+version = "1.0.9"
 description = ""
 authors = ["Chroma Agency, Matias Rivera <mrivera@chroma.agency>"]
 readme = "README.md"


### PR DESCRIPTION
Use the PR head ref for checkout instead of hardcoded main branch to ensure correct branch is used during CI runs